### PR TITLE
Redirect output

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -70,6 +70,8 @@ func (d *libpqDriver) Open(dsn string) (driver.Conn, error) {
 		return nil, ErrFetchingOids
 	}
 
+	redirectOutput(db)
+
 	return &libpqConn{
 		db:        db,
 		oids:      oids,
@@ -429,7 +431,7 @@ func (r *libpqRows) Next(dest []driver.Value) error {
 				return errors.New(fmt.Sprint("libpq: could not parse TIMESTAMP %s: %s", val, err))
 			}
 		case r.s.c.oids.TimestampTz:
-			for _, timeFormat := range []string {
+			for _, timeFormat := range []string{
 				"2006-01-02 15:04:05-07",
 				"2006-01-02 15:04:05.000000-07",
 				"2006-01-02 15:04:05-07:00",

--- a/notice.go
+++ b/notice.go
@@ -1,0 +1,45 @@
+package libpq
+
+/*
+#include <stdlib.h>
+#include <libpq-fe.h>
+
+extern void go_callback_log(char * message);
+
+static void notice(void * arg, char * message)
+{
+    go_callback_log(message);
+}
+
+static void setNotice(PGconn *conn)
+{
+    // we need that cast to suppress issue with const qualifier
+    // that is not supported by cgo
+    PQsetNoticeProcessor(conn, (PQnoticeProcessor)notice,NULL);
+}
+
+*/
+import "C"
+
+func redirectOutput(db *C.PGconn) {
+	if logger != nil {
+		C.setNotice(db)
+	}
+}
+
+type Logger func(message string)
+
+var logger Logger
+
+func SetLogger(l Logger) {
+	if l == nil {
+		panic("can't set empty logger")
+	}
+	logger = l
+}
+
+//export go_callback_log
+func go_callback_log(message *C.char) {
+	// this is possible only if logger is not null
+	logger(C.GoString(message))
+}

--- a/notice.go
+++ b/notice.go
@@ -8,14 +8,14 @@ extern void go_callback_log(char * message);
 
 static void notice(void * arg, char * message)
 {
-    go_callback_log(message);
+	go_callback_log(message);
 }
 
 static void setNotice(PGconn *conn)
 {
-    // we need that cast to suppress issue with const qualifier
-    // that is not supported by cgo
-    PQsetNoticeProcessor(conn, (PQnoticeProcessor)notice,NULL);
+	// we need that cast to suppress issue with const qualifier
+	// that is not supported by cgo
+	PQsetNoticeProcessor(conn, (PQnoticeProcessor)notice,NULL);
 }
 
 */
@@ -31,6 +31,8 @@ type Logger func(message string)
 
 var logger Logger
 
+// SetLogger redirects notifications for all new connections
+// to a callback
 func SetLogger(l Logger) {
 	if l == nil {
 		panic("can't set empty logger")


### PR DESCRIPTION
By default PostgreSQL native driver writes to the stderr, which makes production use rather messy. This pull request allows to redirect output to a go callback function via `PQsetNoticeProcessor`
